### PR TITLE
Fix two imports

### DIFF
--- a/src/pages/manual/plugin-word-count.md
+++ b/src/pages/manual/plugin-word-count.md
@@ -233,8 +233,8 @@ The second file is a React Component class, `lib/wordcount-message-dialog.js`, w
 ```jsx
 'use babel';
 
-import { React } from 'inkdrop';
-import { CompositeDisposable } from 'inkdrop';
+import * as React from 'react';
+import { CompositeDisposable } from 'event-kit';
 
 export default class WordcountMessageDialog extends React.Component {
 


### PR DESCRIPTION
Two of the imports on the [Plugin: Word Count](https://docs.inkdrop.app/manual/plugin-word-count#understanding-the-generated-code) page no longer work, this PR fixes them.