### PR TITLE
editor.codeMirror -> editor.cm

### DIFF
--- a/src/pages/reference/mde.md
+++ b/src/pages/reference/mde.md
@@ -45,7 +45,7 @@ For example, you can change the editor option like so:
 
 ```js
 const mde = inkdrop.getActiveEditorOrThrowError()
-mde.codeMirror.setOption('lineNumbers', true)
+mde.cm.setOption('lineNumbers', true)
 ```
 
 All available CodeMirror APIs are [documented here](https://codemirror.net/doc/manual.html).


### PR DESCRIPTION
[MDE (Markdown Editor)](https://docs.inkdrop.app/reference/mde#extending-inkdrop-editor) contains outdated sample code using `editor.codeMirror`. This PR fixes that.