### PR TITLE
Improved the tips on the 'Creating a Theme' page and small text error on 'Config' page

### DIFF
--- a/src/pages/manual/creating-a-theme.md
+++ b/src/pages/manual/creating-a-theme.md
@@ -28,7 +28,7 @@ Themes are pretty straightforward but it's still helpful to be familiar with a f
 ## Creating a Syntax Theme
 
 <div class="ui message info">
-  <strong>Tip:</strong> Syntax themes should end with <code>-syntax</code>, UI themes should end with <code>-ui</code> and Preview themes should end with <code>-preview</code>.
+  <strong>Tip:</strong> Syntax themes should end with <code>-syntax</code>.
 </div>
 
 Let's create your first theme which is called `motif-syntax`.
@@ -58,6 +58,10 @@ After making changes, reload the app to reflected changes.
 
 ## Creating a UI Theme
 
+<div class="ui message info">
+  <strong>Tip:</strong> UI themes should end with <code>-ui</code> or for dark theme<code>-dark-ui</code>.
+</div>
+
 To create a UI theme, do the following:
 
 1. fork the [Inkdrop's default UI theme repository on GitHub](https://github.com/inkdropapp/inkdrop-default-light-ui-theme)
@@ -81,6 +85,11 @@ Inkdrop's UI elements are styled with [CSS variables](https://developer.mozilla.
 Inkdrop's CSS Variables are defined in `src/definitions/globals/variables.less`, and you can change them by editing `src/themes/default/globals/site.variables`.
 
 ## Creating a Preview Theme
+
+<div class="ui message info">
+  <strong>Tip:</strong> Preview themes should end with <code>-preview</code>.
+</div>
+
 Let's create your first theme which is called `motif-preview`.
 To create a preview theme, do the following:
 

--- a/src/pages/reference/config.md
+++ b/src/pages/reference/config.md
@@ -183,7 +183,7 @@ In this example, the setting must be one of the 3 strings:
 ### title and description
 
 The settings view will use the `title` and `description` keys to display your config setting in a readable way.
-By default the settings view humanizes your config key, so `someSeting` becomes `Some Setting`.
+By default the settings view humanizes your config key, so `someSetting` becomes `Some Setting`.
 In some cases, this is confusing for users, and a more descriptive title is useful.
 
 Descriptions will be displayed below the title in the settings view.


### PR DESCRIPTION
# Description

## Improved the tips on the 'Creating a Theme' page 

- Syntax theme had a tip that was concerning all the themes, so I changed it that way that tips are now on each separate sections of themes.
- I added mention about the required `dark-ui` suffix for dark theme.

## Small text error on 'Config' page

- Just one character was missing and I happened to notice it while reading through the documentation. Did not make sense to do separate PR just for that.