### PR TITLE
fix: clone submodule repositories recursively

### DIFF
--- a/src/pages/manual/plugin-for-mobile.md
+++ b/src/pages/manual/plugin-for-mobile.md
@@ -65,7 +65,7 @@ Fork [inkdrop-mobile-plugins](https://github.com/inkdropapp/inkdrop-mobile-plugi
 Then, clone it:
 
 ```sh
-git clone https://github.com/<YOUR_FORK_OF_inkdrop-mobile-plugins>.git
+git clone https://github.com/<YOUR_FORK_OF_inkdrop-mobile-plugins>.git --recursive
 cd inkdrop-mobile-plugins
 ```
 


### PR DESCRIPTION
Hi.

I'm trying to get my plugins to work on mobile as well.
When cloning my repo forked from `inkdropapp/inkdrop-mobile-plugins` , I found cloned submodule packages (breaks, embed, flowchart, ...) are all empty and thus `npm run build` fails.

<img width="520" alt="Screen Shot 2020-10-02 at 22 33 59" src="https://user-images.githubusercontent.com/39664774/94929673-5f2f3400-0500-11eb-90c9-67bb1206c127.png">

We need a `--recursive` flag when `git clone` the forked repo to fully clone submodule packages.