### PR TITLE
Remove useless semicolon in creating-a-note-template.md

### DIFF
--- a/src/pages/manual/creating-a-note-template.md
+++ b/src/pages/manual/creating-a-note-template.md
@@ -174,7 +174,7 @@ You can accomplish that by creating new command and associating it with the same
 Let's make a command named `custom:new-note` in your `init.js`:
 
 ```js
-;(async () => {
+(async () => {
   const db = inkdrop.main.dataStore.getLocalDB()
   const template = await db.notes.get("note:08zdMqQyj")
 


### PR DESCRIPTION
The codeblock in `Override default behavior of "core:new-note"` has a semicolon at the start of the code that is not needed and may cause confusion as to why it's there for people unfamiliar with javascript.