### PR TITLE
Basic usage page. A small refactor.

### DIFF
--- a/src/pages/manual/basic-usage.md
+++ b/src/pages/manual/basic-usage.md
@@ -22,9 +22,9 @@ Inkdrop interface is broken up into 3 main sections.
 
 **More useful shortcuts:**
 
-- <kbd>Command+E</kbd> or <kbd>Ctrl+E</kbd> — to toggle switch between the editor and preview modes.
+- <kbd>Command+E</kbd> or <kbd>Ctrl+E</kbd> — to switch between the editor and preview modes.
 - <kbd>Command+P</kbd> or <kbd>Ctrl+P</kbd> — to display the editor and preview side-by-side.
-- <kbd>Command+Shift+D</kbd> or <kbd>Ctrl+Shift+D</kbd> — to enter/leave the Zen Mode 🧘 Is when the sidebar and note list are hidden, and you can focus on the writing process.
+- <kbd>Command+Shift+D</kbd> or <kbd>Ctrl+Shift+D</kbd> — to enter/leave the 'Distraction Free Mode' 🧘 Is when the sidebar and note list are hidden, and you can focus on the writing process.
 
 ## Create new note and notebook
 

--- a/src/pages/manual/basic-usage.md
+++ b/src/pages/manual/basic-usage.md
@@ -6,48 +6,63 @@ path: "/manual/basic-usage"
 title: "Basic Usage"
 ---
 
-## Inkdrop has three parts
+## Get acquainted with Inkdrop interface
+
+Inkdrop interface is broken up into 3 main sections.
 
 ![Layout](./basic-usage_screen.png)
 
-- **Sidebar** (on the left): it lists notebooks, statuses and tags here. Notebooks are like folders you can create recursively. Statuses are additional information to treat notes as tasks. Tags are like labels which can link notes with related topic. Sidebar can be toggled by pressing <kbd>Cmd + /</kbd> on macOS or <kbd>Ctrl + /</kbd> on Windows and Linux.
-- **Note list** (in the middle): all your notes live here, ordered by modification date by default. You can search notes with keywords from a search bar on the top of it.
-- **Editor** (on the right): this is where your magic happens; you're looking at it. 😄 Press <kbd>Cmd + E</kbd> / <kbd>Ctrl + E</kbd> to toggle editor/preview, or press <kbd>Cmd + P</kbd> / <kbd>Ctrl + P</kbd> to toggle side-by-side mode.
+- **Sidebar** is the leftmost section. It lists notebooks, statuses, and tags. 
+  - Notebooks are like folders that store your notes. You can nest notebooks in one another as deeply as needed.
+  - Statuses help you treat notes as tasks and, for example, display only active or completed ones. 
+  - Tags are like labels that let you link notes with one another. For example, if they relate to a common topic.
+  You can toggle the Sidebar by pressing <kbd>Command+/</kbd> on macOS or <kbd>Ctrl+/</kbd> on Windows and Linux.
+- **Note list** is located amid. All your notes live here ordered by modification date by default. You can search for notes via the search box at the very top of the section.
+- **Editor** is the rightmost section. This is where your magic happens 🪄 — your workspace. 
 
-Press <kbd>Cmd+Shift+D</kbd> / <kbd>Ctrl+Shift+D</kbd> to enter/leave _Distraction Free Mode_ which hides sidebar and note list.
+**More useful shortcuts:**
 
-## Creating new note and notebook
+- <kbd>Command+E</kbd> or <kbd>Ctrl+E</kbd> — to toggle switch between the editor and preview modes.
+- <kbd>Command+P</kbd> or <kbd>Ctrl+P</kbd> — to display the editor and preview side-by-side.
+- <kbd>Command+Shift+D</kbd> or <kbd>Ctrl+Shift+D</kbd> — to enter/leave the Zen Mode 🧘 Is when the sidebar and note list are hidden, and you can focus on the writing process.
 
-To create new note, you can either push a button on the right top of the note list or input keybind <kbd>Cmd+N</kbd> / <kbd>Ctrl+N</kbd>.
+## Create new note and notebook
+
+To create a new note, you can either click the pencil icon on the right top of the note list or press <kbd>Command+N</kbd> / <kbd>Ctrl+N</kbd>. The newly created note will appear in the **Note list** section.
 
 ![AddNote](./basic-usage_addnote.png)
 
-To create new notebook, click 'Add' button on the right of 'Notebooks' section:
+To create a new notebook, click the plus icon next to the **Notebooks** title:
 
 ![AddBook](./basic-usage_addbook.png)
 
-To create a sub notebook, right click on the notebook item which would be parent and choose "New Sub Notebook.." menu.
+To create a sub notebook: 
+
+1. Right-click the notebook, which will be the parent, and select **New Sub Notebook..**.
+2. Provide a title for the nested notebook.
+3. Click **Create**.  
+The newly created notebook will appear inside the parent one.  
+
 
 ## Settings and preferences
 
-Inkdrop has a number of settings and preferences you can modify in the Preferences View.
+Inkdrop has the **Preferences** view where you can fine-tune look and feel of the app. To open the **Preferences** view, take the following steps:
 
-To open the Settings View, you can:
+### MacOS
 
-- on macOS:
-  - Use the _Inkdrop > Preferences_ menu item in the menu bar
-  - Use the <kbd>Cmd+,</kbd> keybinding
-- on Windows & Linux:
-  - Use the _File > Settings_ menu item in the menu bar
-  - Use the <kbd>Ctrl+,</kbd> keybinding
+Go to **Inkdrop** > **Preferences** in the menu bar. Alternatively, you can press <kbd>Command+,</kbd>. 
 
-And you should see the window like this:
+### Windows and Linux
+
+Go to **File** > **Settings** in the menu bar. Alternatively, you can press <kbd>Ctrl+,</kbd>.
+
+And you will see the window like this:
 
 ![Preferences](./basic-usage_preferences.png)
 
 ## User data directory
 
-Inkdrop stores your data and config in local at the following path:
+Inkdrop stores your data and config locally at the following path:
 
 - on macOS: `~/Library/Application Support/inkdrop/`
 - on Windows: `%APPDATA%\inkdrop\`
@@ -55,11 +70,11 @@ Inkdrop stores your data and config in local at the following path:
   - deb/rpm: `~/.config/inkdrop/`
   - Snap: `~/snap/inkdrop/current/.config/inkdrop/`
 
-You can open it up in a file manager from _Preferences -> General -> Open Config Folder_.
+To open it in a file manager, go to **Preferences** > **General** and select **Open Config Folder**.
 
-This directory has the following files and folders:
+The config folder has the following files and folders:
 
-- `config.cson`: The app config file in [CSON format](https://github.com/bevry/cson#what-is-cson)
-- `keymap.cson`: The keybindings config file in [CSON format](https://github.com/bevry/cson#what-is-cson)
-- `packages/`: Installed plugins
-- `db/`: The local database
+- `config.cson` — app config file in the [CSON format](https://github.com/bevry/cson#what-is-cson)
+- `keymap.cson` — keybindings config file in the [CSON format](https://github.com/bevry/cson#what-is-cson)
+- `packages/` — installed plugins
+- `db/` — local database

--- a/src/pages/manual/basic-usage.md
+++ b/src/pages/manual/basic-usage.md
@@ -16,7 +16,7 @@ Inkdrop interface is broken up into 3 main sections.
   - Notebooks are like folders that store your notes. You can nest notebooks in one another as deeply as needed.
   - Statuses help you treat notes as tasks and, for example, display only active or completed ones. 
   - Tags are like labels that let you link notes with one another. For example, if they relate to a common topic.
-  You can toggle the Sidebar by pressing <kbd>Command+/</kbd> on macOS or <kbd>Ctrl+/</kbd> on Windows and Linux.
+  You can toggle the Sidebar by using <kbd>Command+/</kbd> on macOS or <kbd>Ctrl+/</kbd> on Windows and Linux.
 - **Note list** is located amid. All your notes live here ordered by modification date by default. You can search for notes via the search box at the very top of the section.
 - **Editor** is the rightmost section. This is where your magic happens 🪄 — your workspace. 
 
@@ -28,7 +28,7 @@ Inkdrop interface is broken up into 3 main sections.
 
 ## Create new note and notebook
 
-To create a new note, you can either click the pencil icon on the right top of the note list or press <kbd>Command+N</kbd> / <kbd>Ctrl+N</kbd>. The newly created note will appear in the **Note list** section.
+To create a new note, you can either click the pencil icon on the right top of the note list or use the <kbd>Command+N</kbd> / <kbd>Ctrl+N</kbd> shortcut. The newly created note will appear in the **Note list** section.
 
 ![AddNote](./basic-usage_addnote.png)
 
@@ -50,11 +50,11 @@ Inkdrop has the **Preferences** view where you can fine-tune look and feel of th
 
 ### MacOS
 
-Go to **Inkdrop** > **Preferences** in the menu bar. Alternatively, you can press <kbd>Command+,</kbd>. 
+Go to **Inkdrop** > **Preferences** in the menu bar. Alternatively, you can use the <kbd>Command+,</kbd> shortcut. 
 
 ### Windows and Linux
 
-Go to **File** > **Settings** in the menu bar. Alternatively, you can press <kbd>Ctrl+,</kbd>.
+Go to **File** > **Settings** in the menu bar. Alternatively, you can use the <kbd>Ctrl+,</kbd> shortcut.
 
 And you will see the window like this:
 

--- a/src/pages/manual/quick-start-guide.md
+++ b/src/pages/manual/quick-start-guide.md
@@ -40,7 +40,7 @@ You have two options to install it.
 ### via Snap
 
 <div class="ui info message">
-If you don't have <code>snap</code> yet, please <a href="https://snapcraft.io/docs/core/install" target="_blank">install it</a> beforehand.
+If you don't have <code>snapd</code> yet, please <a href="https://snapcraft.io/docs/core/install" target="_blank">install it</a> beforehand.
 </div>
 
 The app is [available on Snap Store](https://snapcraft.io/inkdrop).

--- a/src/pages/manual/quick-start-guide.md
+++ b/src/pages/manual/quick-start-guide.md
@@ -12,8 +12,8 @@ To get started with Inkdrop, we'll need to get it on your system.
 ## Creating your Inkdrop account
 
 First, go to [Inkdrop website](https://inkdrop.app/) and sign up.
-Inkdrop will prepare new database for storing your note data.
-Also your account can be used for publishing your plugins and so on.
+Inkdrop will prepare a new database for storing your note data.
+Also, your account can be used for publishing your plugins and so on.
 
 ## Downloading the app
 
@@ -21,17 +21,17 @@ After you set up an account and log in, you should see a download button as show
 
 ![Download](quick-start-guide_download.png)
 
-Desktop application is ready for macOS, Windows and Linux, so choose one for your environment:
+Desktop application is ready for macOS, Windows, and Linux, so choose one for your environment:
 
 ![Download](quick-start-guide_download2.png)
 
 ## Installing Inkdrop on macOS
 
-Inkdrop follows the standard Mac zip installation process. You can download the `Inkdrop-x.y.z-Mac.zip` file from the Inkdrop website. Once you have that file, you can click on it to extract the application and then drag the new Inkdrop application into your "Applications" folder.
+Inkdrop follows the standard Mac zip installation process. You can download the `Inkdrop-x.y.z-Mac.zip` file from the Inkdrop website. Once you have that file, you can double click it to extract the application and drag the new Inkdrop application into your "Applications" folder.
 
 ## Installing Inkdrop on Windows
 
-Inkdrop is both available with a Windows installer and zip archive. The installer is recommended because it can provide auto-update features which automatically update to the latest version of the Inkdrop app.
+Inkdrop is both available with a Windows installer and zip archive. The installer is recommended because it can provide auto-update features that automatically update the Inkdrop app to the latest version.
 
 ## Installing Inkdrop on Linux
 
@@ -40,19 +40,19 @@ You have two options to install it.
 ### via Snap
 
 <div class="ui info message">
-If you don't have <code>snapd</code> yet, please <a href="https://snapcraft.io/docs/core/install" target="_blank">install it</a> beforehand.
+If you don't have <code>snap</code> yet, please <a href="https://snapcraft.io/docs/core/install" target="_blank">install it</a> beforehand.
 </div>
 
 The app is [available on Snap Store](https://snapcraft.io/inkdrop).
-You can install the app via Snap Store like following:
+You can install the app via Snap Store like the following:
 
 ```bash
 sudo snap install inkdrop
-# Allow the app to access to your keyring
+# Allow the app to access your keyring
 sudo snap connect inkdrop:password-manager-service
 ```
 
-You can easily update the app by running below command:
+You can easily update the app by running the command below:
 
 ```bash
 sudo snap refresh inkdrop
@@ -60,7 +60,7 @@ sudo snap refresh inkdrop
 
 ### via Package
 
-To install Inkdrop on Linux, you can download a Debian package, a RPM package or a zip archive.
+To install Inkdrop on Linux, you can download a Debian package, an RPM package, or a zip archive.
 The packages do not have auto-update features.
 So when you would like to upgrade to a new release of Inkdrop, you will have to repeat this installation process.
 
@@ -73,7 +73,7 @@ wget https://api.inkdrop.app/download/linux/deb -O /tmp/inkdrop.deb && sudo dpkg
 sudo apt-get -f install
 ```
 
-#### RedHat, Fedora or related systems
+#### RedHat, Fedora, or related systems
 
 ```bash
 wget https://api.inkdrop.app/download/linux/rpm -O /tmp/inkdrop.rpm && sudo yum install /tmp/inkdrop.rpm && rm /tmp/inkdrop.rpm
@@ -81,7 +81,7 @@ wget https://api.inkdrop.app/download/linux/rpm -O /tmp/inkdrop.rpm && sudo yum 
 
 ## Log in
 
-When you first open Inkdrop, you should see Log-in screen like this:
+When you first open Inkdrop, you should see a Log-in screen like this:
 
 ![Login](quick-start-guide_login.png)
 

--- a/src/pages/manual/quick-start-guide.md
+++ b/src/pages/manual/quick-start-guide.md
@@ -27,7 +27,7 @@ Desktop application is ready for macOS, Windows, and Linux, so choose one for yo
 
 ## Installing Inkdrop on macOS
 
-Inkdrop follows the standard Mac zip installation process. You can download the `Inkdrop-x.y.z-Mac.zip` file from the Inkdrop website. Once you have that file, you can double click it to extract the application and drag the new Inkdrop application into your "Applications" folder.
+Inkdrop follows the standard Mac zip installation process. You can download the `Inkdrop-x.y.z-Mac.zip` file from the Inkdrop website. Once you have that file, you can double-click it to extract the application and drag the new Inkdrop application into your "Applications" folder.
 
 ## Installing Inkdrop on Windows
 


### PR DESCRIPTION
1. Tried to simplify the page content in general (use plain english, small restructures of the content, and bold prominent parts or parts of the interface).
2. Raplace gerunds in headings with infinitives.
3. Split long menu items into submenus.
4. Cmd > Command (as it appears on the keyboard).
5. Add a couple of step results for users to understand what outcome to expect and what to look at.
6. A couple of missing articles.
7. Break instructions into numbered lists (where possible).