### PR TITLE
fix(icon): set vertical align to middle

### DIFF
--- a/src/components/doc-content.less
+++ b/src/components/doc-content.less
@@ -167,6 +167,7 @@
 
   .ui-icon {
     color: #b3b2b3;
+    vertical-align: middle;
 
     svg {
       width: 20px;


### PR DESCRIPTION
https://github.com/inkdropapp/docs/pull/42#issuecomment-1200245767

`vertical-align: middle` should fix this.

cc @dmitriyrotaenko 