### PR TITLE
Fix anchor references in list of links at top of data model page

### DIFF
--- a/src/pages/reference/data-models.md
+++ b/src/pages/reference/data-models.md
@@ -5,10 +5,10 @@ path: /reference/data-models
 title: Data Models
 ---
 
-* [Book](#a-nameresource-bookbooka)
-* [File](#a-nameresource-filefilea)
-* [Note](#a-nameresource-notenotea)
-* [Tag](#a-nameresource-tagtaga)
+* [Book](#resource-book)
+* [File](#resource-file)
+* [Note](#resource-note)
+* [Tag](#resource-tag)
 
 <a name="#resource-book"></a>
 ## Book


### PR DESCRIPTION
The anchor links now match up to the anchors in the document