### PR TITLE
fix(manual): update reload shortcuts

### DIFF
--- a/src/pages/manual/adding-styles-for-text-annotation.md
+++ b/src/pages/manual/adding-styles-for-text-annotation.md
@@ -33,7 +33,7 @@ And you can define stylesheets only applied to notes in this notebook.
 
 ## Enable Development Mode
 
-Let Inkdrop run in **Development Mode** by selecting the _Inkdrop > Preferences_ menu, clicking the _General_ tab on the left hand navigation, and check the "_Development Mode_", then reload the app by pressing `Alt+Cmd+Ctrl+L` / `Alt+Ctrl+L`
+Let Inkdrop run in **Development Mode** by selecting the _Inkdrop > Preferences_ menu, clicking the _General_ tab on the left hand navigation, and check the "_Development Mode_", then reload the app by pressing <kbd>Alt+Cmd+Ctrl+R</kbd> / <kbd>Alt+Ctrl+R</kbd>
 
 ## Check the class name of the editor
 
@@ -83,7 +83,7 @@ Create a `styles.less` in [your data directory](/manual/basic-usage#user-data-di
 }
 ```
 
-Reload the app by selecting the _Developer -> Reload_ menu or by pressing `Alt+Cmd+Ctrl+L` / `Alt+Ctrl+L`.
+Reload the app by selecting the _Developer -> Reload_ menu or by pressing <kbd>Alt+Cmd+Ctrl+R</kbd> / <kbd>Alt+Ctrl+R</kbd>.
 Then, boom! You should see that your notes got special highlightings for italic and strong emphasises.
 
 ![Result](adding-styles-for-text-annotation_result.png)

--- a/src/pages/manual/creating-a-theme.md
+++ b/src/pages/manual/creating-a-theme.md
@@ -37,10 +37,10 @@ To create a syntax theme, do the following:
 1. fork the [Inkdrop's sample repository on GitHub](https://github.com/inkdropapp/inkdrop-default-light-syntax-theme)
 2. Clone the forked repository to the directory named `motif-syntax` in the local filesystem
 3. Open a terminal in the forked theme's directory
-4. Let Inkdrop run in **Development Mode** by selecting the menu _Inkdrop > Preferences_ on macOS or _File > Settings_ on Windows and Linux, clicking the _General_ tab on the left hand navigation, and check the "_Development Mode_", then reload the app by pressing `Alt+Cmd+Ctrl+R` / `Alt+Ctrl+R`
+4. Let Inkdrop run in **Development Mode** by selecting the menu _Inkdrop > Preferences_ on macOS or _File > Settings_ on Windows and Linux, clicking the _General_ tab on the left hand navigation, and check the "_Development Mode_", then reload the app by pressing <kbd>Alt+Cmd+Ctrl+R</kbd> / <kbd>Alt+Ctrl+R</kbd>
 5. Change the name of the theme in the theme's `package.json` file
 6. Run `ipm link --dev` to symlink your repository to `~/Library/Application Support/inkdrop/dev/packages`
-7. Reload Inkdrop using `Alt+Cmd+Ctrl+L` / `Alt+Ctrl+L`
+7. Reload Inkdrop using <kbd>Alt+Cmd+Ctrl+R</kbd> / <kbd>Alt+Ctrl+R</kbd>
 8. Enable the theme via the "_Syntax Theme_" drop-down in the "Themes" tab of the Preferences
 
 Now you are ready to make changes!
@@ -67,12 +67,12 @@ To create a UI theme, do the following:
 1. fork the [Inkdrop's default UI theme repository on GitHub](https://github.com/inkdropapp/inkdrop-default-light-ui-theme)
 2. Clone the forked repository to the local filesystem
 3. Open a terminal in the forked theme's directory
-4. Let Inkdrop run in **Development Mode** by selecting the menu _Inkdrop > Preferences_ on macOS or _File > Settings_ on Windows and Linux, clicking the _General_ tab on the left hand navigation, and check the "_Development Mode_", then reload the app by pressing `Alt+Cmd+Ctrl+L` / `Alt+Ctrl+L`
+4. Let Inkdrop run in **Development Mode** by selecting the menu _Inkdrop > Preferences_ on macOS or _File > Settings_ on Windows and Linux, clicking the _General_ tab on the left hand navigation, and check the "_Development Mode_", then reload the app by pressing <kbd>Alt+Cmd+Ctrl+R</kbd> / <kbd>Alt+Ctrl+R</kbd>
 5. Change the name of the theme in the theme's `package.json` file
 6. Run `npm install` to install dependencies
 7. Run `gulp build` to build theme files
 8. Run `ipm link --dev` to symlink your repository to `~/Library/Application Support/inkdrop/dev/packages`
-9. Reload Inkdrop using `Alt+Cmd+Ctrl+L` / `Alt+Ctrl+L`
+9. Reload Inkdrop using <kbd>Alt+Cmd+Ctrl+R</kbd> / <kbd>Alt+Ctrl+R</kbd>
 10. Enable the theme via the "_UI Theme_" drop-down in the "Themes" tab of the Preferences
 
 Now you are ready to make changes!
@@ -96,10 +96,10 @@ To create a preview theme, do the following:
 1. fork the [Inkdrop's sample repository on GitHub](https://github.com/inkdropapp/inkdrop-github-preview-theme)
 2. Clone the forked repository to the directory named `motif-preview` in the local filesystem
 3. Open a terminal in the forked theme's directory
-4. Let Inkdrop run in **Development Mode** by selecting the menu _Inkdrop > Preferences_ on macOS or _File > Settings_ on Windows and Linux, clicking the _General_ tab on the left hand navigation, and check the "_Development Mode_", then reload the app by pressing `Alt+Cmd+Ctrl+L` / `Alt+Ctrl+L`
+4. Let Inkdrop run in **Development Mode** by selecting the menu _Inkdrop > Preferences_ on macOS or _File > Settings_ on Windows and Linux, clicking the _General_ tab on the left hand navigation, and check the "_Development Mode_", then reload the app by pressing <kbd>Alt+Cmd+Ctrl+R</kbd> / <kbd>Alt+Ctrl+R</kbd>
 5. Change the name of the theme in the theme's `package.json` file
 6. Run `ipm link --dev` to symlink your repository to `~/Library/Application Support/inkdrop/dev/packages`
-7. Reload Inkdrop using `Alt+Cmd+Ctrl+L` / `Alt+Ctrl+L`
+7. Reload Inkdrop using <kbd>Alt+Cmd+Ctrl+R</kbd> / <kbd>Alt+Ctrl+R</kbd>
 8. Enable the theme via the "_Preview Theme_" drop-down in the "Themes" tab of the Preferences
 
 Now you are ready to make changes!

--- a/src/pages/manual/plugin-word-count.md
+++ b/src/pages/manual/plugin-word-count.md
@@ -110,7 +110,7 @@ You can provide key bindings for commonly used actions for your extension, espec
 }
 ```
 
-This means that if you press `Alt+Ctrl+O`, our package will run the `wordcount:toggle` command. We'll look at that code next, but if you want to change the default key mapping, you can do that in this file.
+This means that if you press <kbd>Alt+Ctrl+O</kbd>, our package will run the `wordcount:toggle` command. We'll look at that code next, but if you want to change the default key mapping, you can do that in this file.
 
 Keymaps are placed in the `keymaps` subdirectory. By default, all keymaps are loaded in alphabetical order. An optional `keymaps` array in your `package.json` can specify which keymaps to load and in what order.
 
@@ -217,7 +217,7 @@ You can install the plugin locally for development.
 
 Run `ipm link --dev` to symlink your repository to `/dev/packages` in [the user data directory](/manual/basic-usage#user-data-directory).
 
-Let Inkdrop run in **Development Mode** by selecting the menu _Inkdrop > Preferences_ on macOS or _File > Settings_ on Windows and Linux, clicking the _General_ tab on the left hand navigation, and check the "_Development Mode_", then reload the app by pressing `Alt+Cmd+Ctrl+L` / `Alt+Ctrl+L`.
+Let Inkdrop run in **Development Mode** by selecting the menu _Inkdrop > Preferences_ on macOS or _File > Settings_ on Windows and Linux, clicking the _General_ tab on the left hand navigation, and check the "_Development Mode_", then reload the app by pressing <kbd>Alt+Cmd+Ctrl+R</kbd> / <kbd>Alt+Ctrl+R</kbd>.
 
 ### Understanding the Generated Code
 

--- a/src/pages/manual/writing-note.md
+++ b/src/pages/manual/writing-note.md
@@ -21,7 +21,7 @@ An untitled empty note is created. Name the note, so it'll be easier to look for
 
 ## Delete notes
 
-To delete a note, right-click the note and select the **Move to trash** option. Alternatively, you can select a note with a left-click and use the <kbd>Command+Del</kbd> / <kbd>Ctrl+Del</kbd> shortcut.
+To delete a note, right-click the note and select the **Move to trash** option. Alternatively, you can select a note with a left-click and use the <kbd>Command+Backspace</kbd> / <kbd>Ctrl+Backspace</kbd> shortcut.
 
 Inkdrop also lets you delete multiple notes at once. To do this:
 

--- a/src/pages/manual/writing-note.md
+++ b/src/pages/manual/writing-note.md
@@ -21,7 +21,7 @@ An untitled empty note is created. Name the note, so it'll be easier to look for
 
 ## Delete notes
 
-To delete a note, right-click the note and select the **Move to trash** option. Alternatively, you can select a note with a left-click and use the <kbd>Command+Backspace</kbd> / <kbd>Ctrl+Backspace</kbd> shortcut.
+To delete a note, right-click the note and select the **Move to trash** option. Alternatively, you can select a note with a left-click and use the <kbd>Command+Del</kbd> / <kbd>Ctrl+Backspace</kbd> shortcut.
 
 Inkdrop also lets you delete multiple notes at once. To do this:
 


### PR DESCRIPTION
Updated with correct **_reload app_** shortcut across all docs. **_Delete note_** shortcut was updated as well.

Also I've noticed that **_multiple deletion_** of notes isn't working with holding <kbd>CTRL</kbd>. It works just fine with <kbd>SHIFT</kbd>, so maybe it's just wrong key or selecting multiple notes with <kbd>CTRL</kbd> was removed/bugged.
